### PR TITLE
Use LMP for copyDeps in package

### DIFF
--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -31,7 +31,7 @@ COPY --chown=1001:0 \
     /config/apps
 
 COPY --chown=1001:0 \
-    target/liberty/wlp/usr/shared/resources/*.jar \
+    target/liberty/wlp/usr/shared/resources/postgresql-*.jar \
     /opt/ol/wlp/usr/shared/resources/
 
 USER 1001

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -111,25 +111,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>org.postgresql</includeGroupIds>
-                            <includeArtifactIds>postgresql</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}/liberty/wlp/usr/shared/resources</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <!-- end::maven-dependency-plugin[] -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.10</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <copyDependencies>
                         <dependencyGroup>
@@ -141,7 +137,6 @@
                         </dependencyGroup>
                     </copyDependencies>
                 </configuration>
-                <version>3.10</version>
             </plugin>
             <!-- tag::failsafe[] -->
             <plugin>


### PR DESCRIPTION
Fixes #41. 

Might be better just to bind the 'create' goal to prepare-package.  At least we don't have to duplicate the copyDeps config in the dependency-plugin.

This overlaps the discussion in https://github.com/openLiberty/ci.maven/issues/739
 
Obviously the doc would need to be updated, just wanted to raise the suggestion as a first step.